### PR TITLE
FIX: Notify task should come last when running watch tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -117,7 +117,7 @@ module.exports = function(grunt) {
 		watch: {
 			uglify: {
 				files: 'themes/<%= pkg.name %>/js/src/app.js',
-				tasks: ['js'],
+				tasks: ['js', 'notify'],
 				options: {
 					spawn: false,
 					interrupt: true,
@@ -126,16 +126,12 @@ module.exports = function(grunt) {
 			},
 			css: {
 				files: 'themes/<%= pkg.name %>/scss/**/*.scss',
-				tasks: ['css'],
+				tasks: ['css', 'notify'],
 				options: {
 					spawn: false,
 					interrupt: true,
 					debounceDelay: 250
 				}
-			},
-			notify: {
-				files: ['<%= watch.uglify.files %>', '<%= watch.css.files %>'],
-				tasks: ['notify']
 			}
 		},
 
@@ -146,7 +142,7 @@ module.exports = function(grunt) {
 					title: 'Grunt',
 					message: 'Tasks complete',
 				}
-			},
+			}
 		}
 
 	});


### PR DESCRIPTION
The `spawn: false` option caused notify to run whenever it felt like (i.e. before other tasks had actually finished). Moving the separate `watch:notify` task into the `tasks` arrays prevents this (plus it’s more concise).