### PR TITLE
Disable interrupt option for Grunt watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,7 +120,6 @@ module.exports = function(grunt) {
 				tasks: ['js', 'notify'],
 				options: {
 					spawn: false,
-					interrupt: true,
 					debounceDelay: 250
 				}
 			},
@@ -129,7 +128,6 @@ module.exports = function(grunt) {
 				tasks: ['css', 'notify'],
 				options: {
 					spawn: false,
-					interrupt: true,
 					debounceDelay: 250
 				}
 			}


### PR DESCRIPTION
If you save one file, then save a second one while the tasks are running, it’s interrupted but then it stops watching after it’s finished. Seems the `spawn` and `interrupt` options [don’t always play nicely together](https://github.com/gruntjs/grunt-contrib-watch/issues/377). Played around with it, the `spawn` option speeds everything up quite a lot so I think that’s a more desirable feature than `interrupt`.