### PR TITLE
Use forked cssmin package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "gulp-sass": "git+https:\/\/github.com\/stnvh\/gulp-sass.git",
     "gulp-autoprefixer": "^2.0",
     "gulp-combine-mq": "~0.4.0",
-    "gulp-cssmin": "~0.1.0",
+    "gulp-cssmin": "git+https:\/\/github.com\/Bigfork\/gulp-cssmin.git",
     "gulp-jshint": "~1.9.0",
     "gulp-uglify": "^1.0.0",
     "gulp-concat": "^2.0",


### PR DESCRIPTION
[This package](https://github.com/chilijung/gulp-cssmin) currently uses clean-css version 2, which breaks IE8 when using our `@font-size` mixin (specifically it removes the pixel value, leaving only the rem value which IE8 doesn’t understand) and probably a few other things too.