### PR TITLE
Move gulp watch into separate task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -115,10 +115,12 @@ gulp.task('default', function() {
 });
 
 // watch tasks
-gulp.watch('themes/' + pkg.name + '/scss/**/*.scss', function() {
-	gulp.start('css');
-});
+gulp.task('watch', function() {
+	gulp.watch('themes/' + pkg.name + '/scss/**/*.scss', function() {
+		gulp.start('css');
+	});
 
-gulp.watch('themes/' + pkg.name + '/js/src/*.js', function() {
-	gulp.start('js');
+	gulp.watch('themes/' + pkg.name + '/js/src/*.js', function() {
+		gulp.start('js');
+	});
 });


### PR DESCRIPTION
Currently:

- `gulp` triggers CSS & JS compilation, then runs watch tasks (so continues running)

Proposed:

- `gulp` triggers CSS & JS compilation, then exits
- `gulp watch` runs just the watch tasks

So basically this is reverting the behaviour back to how it was with Grunt.

Thoughts?