### PR TITLE
Include linter name in SCSS-lint error output

### DIFF
--- a/gulp/lib/handlers.js
+++ b/gulp/lib/handlers.js
@@ -42,8 +42,8 @@ lint = {
 
 			files.indexOf(base) < 0 && files.push(base);
 
-			generic.log(':' + c.red(result.line) + ' ' +
-				result.reason,
+			generic.log(
+				' - ' + c.red(result.line) + ':' + c.red(result.column) + ' - ' + c.yellow(result.linter) + ': ' + result.reason,
 				{type: 'bad', space: false, pipe: false, file: file}
 			);
 		});


### PR DESCRIPTION
Also adds column number and changes the formatting slightly. Before:
![screen shot 2015-05-08 at 16 50 13](https://cloud.githubusercontent.com/assets/1655548/7539935/68d1f574-f5a2-11e4-83a4-c7c11d2b1133.png)

After:
![screen shot 2015-05-08 at 16 48 55](https://cloud.githubusercontent.com/assets/1655548/7539939/6edf45de-f5a2-11e4-9ca0-34623cd41aa6.png)
