### PR TITLE
Use basic regex minification of CSS

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -7,8 +7,7 @@ var gulp = require('gulp'),
 		rename: {
 			'gulp-tinypng-compress': 'tinypng',
 			'gulp-combine-mq': 'cmq',
-			'gulp-util': 'gutil',
-			'gulp-minify-css': 'minifyCSS'
+			'gulp-util': 'gutil'
 		}
 	}),
 
@@ -68,10 +67,7 @@ gulp.task('css', ['scss-lint'], function() {
 			browsers: ['last 2 versions', 'ie 8', 'ie 9', 'android 2.1']
 		}))
 		.pipe(p.cmq())
-		.pipe(p.minifyCSS({
-			compatibility: 'ie8',
-			processImport: false
-		}))
+		.pipe(handle.minify())
 		.pipe(handle.generic.log('compiled'))
 		.pipe(handle.notify.show('CSS compiled - <%= file.relative %>'))
 		.pipe(gulp.dest(conf.dest));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "gulp-sass": "git+https:\/\/github.com\/stnvh\/gulp-sass.git",
     "gulp-autoprefixer": "^2.0",
     "gulp-combine-mq": "~0.4.0",
-    "gulp-minify-css":"^1.0.0",
     "gulp-jshint": "~1.9.0",
     "gulp-uglify": "^1.0.0",
     "gulp-concat": "^2.0",


### PR DESCRIPTION
Removed the need for minify css, as it causes broken CSS output too often. It was only added to lightly minify after media query concat. 

For now it's using a very small plugin, added in the `handlers.js` export, as there doesn't seem to be a simple CSS minifier which doesn't include an assortment of patchy formatting options!