### PR TITLE
Add babel

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -82,7 +82,10 @@ gulp.task('js', function() {
 	var conf = config('js');
 	return gulp.src(conf.src)
 		.pipe(p.plumber({errorHandler: handle.generic.error}))
-		.pipe(p.jshint())
+		.pipe(p.jshint({
+			esnext: true
+		}))
+		.pipe(p.babel())
 		.pipe(p.uglify())
 		.pipe(p.concat('app.min.js'))
 		.pipe(handle.generic.log('compiled'))

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "gulp-concat": "^2.0",
     "gulp-watch": "^4.0",
     "gulp-tinypng-compress": "^1.1.0",
-    "gulp-css-globbing": "^0.1.8"
+    "gulp-css-globbing": "^0.1.8",
+    "gulp-babel": "5.x"
   },
   "description": "Default",
   "main": "Gulpfile.js",


### PR DESCRIPTION
Add support for ES2015 syntax, JSX and react (via Babel)

It would be appropriate to address #22 as ESLint is a lot better for ES6/JSX linting than JSHint (which would probably error if you started whacking ~~html~~ JSX everywhere)