### PR TITLE
Watch for new/changed pngs, automatically run png task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -120,11 +120,15 @@ gulp.task('default', function() {
 
 // watch tasks
 gulp.task('watch', function() {
-	gulp.watch('themes/' + pkg.name + '/scss/**/*.scss', function() {
+	p.watch('themes/' + pkg.name + '/scss/**/*.scss', function() {
 		gulp.start('css');
 	});
 
-	gulp.watch('themes/' + pkg.name + '/js/src/*.js', function() {
+	p.watch('themes/' + pkg.name + '/js/src/*.js', function() {
 		gulp.start('js');
+	});
+
+	p.watch('themes/' + pkg.name + '/images/src/**/*.png', function() {
+		gulp.start('png');
 	});
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "gulp-watch": "^4.0",
     "gulp-tinypng-compress": "^1.1.0",
     "gulp-css-globbing": "^0.1.8",
-    "gulp-babel": "5.x"
+    "gulp-babel": "5.x",
+    "gulp-watch": "^4.3"
   },
   "description": "Default",
   "main": "Gulpfile.js",


### PR DESCRIPTION
I always forget to run `gulp png` manually, then wonder why my images don’t show.

The plugin is needed because the default `gulp.watch` doesn’t pick up new/deleted files as changes, whereas the plugin does.