### PR TITLE
FIX: max-width queries shouldn't be included in ie8.css

### DIFF
--- a/themes/default/scss/includes/_mixins.scss
+++ b/themes/default/scss/includes/_mixins.scss
@@ -29,13 +29,13 @@
 		$width: unquote($width);
 	}
 	// IE? Strip out media queries
-	@if $_is_ie {
-		@content;
-	} @else {
-		// Otherwise, responsive goodness
+	@if not $_is_ie {
 		@media screen and (#{$minMax}-width: $width) {
 			@content;
 		}
+	} @elseif($minMax == 'min') {
+		// Otherwise, responsive goodness
+		@content;
 	}
 }
 


### PR DESCRIPTION
Can anyone think of a situation where it’d be _helpful_ to output max-width media queries in IE8?

@feejin @stnvh 