### PR TITLE
Add BrowserSync

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,4 +1,5 @@
 var gulp = require('gulp'),
+	bs = require('browser-sync').create(),
 	path = require('path'),
 
 	p = require('gulp-load-plugins')({
@@ -74,7 +75,8 @@ gulp.task('css', ['scss-lint'], function() {
 		.pipe(handle.minify())
 		.pipe(handle.generic.log('compiled'))
 		.pipe(handle.notify.show('CSS compiled - <%= file.relative %>'))
-		.pipe(gulp.dest(conf.dest));
+		.pipe(gulp.dest(conf.dest))
+		.pipe(bs.stream());
 });
 
 // lint, concat and uglify javascript
@@ -120,6 +122,10 @@ gulp.task('default', function() {
 
 // watch tasks
 gulp.task('watch', function() {
+	bs.init({
+		proxy: 'http://' + path.basename(__dirname) + '.dev'
+	});
+
 	p.watch('themes/' + pkg.name + '/scss/**/*.scss', function() {
 		gulp.start('css');
 	});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "gulp-tinypng-compress": "^1.1.0",
     "gulp-css-globbing": "^0.1.8",
     "gulp-babel": "5.x",
-    "gulp-watch": "^4.3"
+    "gulp-watch": "^4.3",
+    "browser-sync": "2.x"
   },
   "description": "Default",
   "main": "Gulpfile.js",


### PR DESCRIPTION
Will start the browsersync proxy on gulp watch, then sync any CSS changes when compiled.